### PR TITLE
Add init file support

### DIFF
--- a/src/javarepl/Repl.java
+++ b/src/javarepl/Repl.java
@@ -15,6 +15,7 @@ import java.io.InputStreamReader;
 import java.lang.management.ManagementPermission;
 import java.lang.reflect.ReflectPermission;
 import java.net.SocketPermission;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.security.CodeSource;
 import java.security.PermissionCollection;
@@ -90,7 +91,7 @@ public class Repl {
         return new Function1<File, List<String>>() {
             @Override
             public List<String> call(File f) throws Exception {
-                List<String> l = Files.readAllLines(f.toPath());
+                List<String> l = Files.readAllLines(f.toPath(), StandardCharsets.UTF_8);
                 System.out.println(l);
                 return l;
             }


### PR DESCRIPTION
Create a file `javarepl.init` in the current folder and each line will be executed when the REPL is started up.

For example:
_javarepl.init_

```
final String foo = "foo";
```

Then the following will be reported by `:list` right after stating the REPL:

```
java> :list
Results:
    java.lang.String foo = "foo"

Types:


Imports:
    java.lang.*
    java.util.*
    java.math.*
    java.lang.Math.*
    java.util.function.*

Methods:
```
