### PR TITLE
Add restart button

### DIFF
--- a/build/packaged.dependencies
+++ b/build/packaged.dependencies
@@ -1,8 +1,8 @@
-mvn:jline:jline:jar:2.11
+mvn:jline:jline:jar:2.12
 
-mvn:cglib:cglib-nodep:jar:2.2
-mvn:org.ow2.asm:asm-all:jar|sources:4.1
-mvn:org.objenesis:objenesis:jar:1.2
+mvn:cglib:cglib:jar:3.1
+mvn:org.ow2.asm:asm-all:jar|sources:4.2
+mvn:org.objenesis:objenesis:jar:2.1
 
 mvn:antlr:antlr:jar:2.7.7
 mvn:org.antlr:stringtemplate:jar|sources:3.2.1

--- a/intellij-plugin/src/javarepl/plugin/JavaREPLConsoleRunner.java
+++ b/intellij-plugin/src/javarepl/plugin/JavaREPLConsoleRunner.java
@@ -181,14 +181,14 @@ public class JavaREPLConsoleRunner {
 
         ArrayList<AnAction> actionList = new ArrayList<AnAction>();
 
+        final AnAction restartAction = createRestartAction(defaultExecutor, myDescriptor);
+        actionList.add(restartAction);
+
         final AnAction stopAction = createStopAction();
         actionList.add(stopAction);
 
         final AnAction closeAction = createCloseAction(defaultExecutor, myDescriptor);
         actionList.add(closeAction);
-
-        final AnAction restartAction = createRestartAction(defaultExecutor, myDescriptor);
-        actionList.add(restartAction);
 
         ArrayList<AnAction> executionActions = createConsoleExecActions(languageConsole,
                 processHandler, consoleHistoryModel);

--- a/intellij-plugin/src/javarepl/plugin/JavaREPLConsoleRunner.java
+++ b/intellij-plugin/src/javarepl/plugin/JavaREPLConsoleRunner.java
@@ -9,6 +9,7 @@ import com.intellij.execution.process.*;
 import com.intellij.execution.ui.ConsoleViewContentType;
 import com.intellij.execution.ui.RunContentDescriptor;
 import com.intellij.execution.ui.actions.CloseAction;
+import com.intellij.icons.AllIcons;
 import com.intellij.ide.CommonActionsManager;
 import com.intellij.lang.java.JavaLanguage;
 import com.intellij.openapi.actionSystem.*;
@@ -186,6 +187,9 @@ public class JavaREPLConsoleRunner {
         final AnAction closeAction = createCloseAction(defaultExecutor, myDescriptor);
         actionList.add(closeAction);
 
+        final AnAction restartAction = createRestartAction(defaultExecutor, myDescriptor);
+        actionList.add(restartAction);
+
         ArrayList<AnAction> executionActions = createConsoleExecActions(languageConsole,
                 processHandler, consoleHistoryModel);
         runAction = executionActions.get(0);
@@ -236,12 +240,23 @@ public class JavaREPLConsoleRunner {
     }
 
 
+    protected AnAction createStopAction() {
+        return ActionManager.getInstance().getAction(IdeActions.ACTION_STOP_PROGRAM);
+    }
+
     protected AnAction createCloseAction(final Executor defaultExecutor, final RunContentDescriptor myDescriptor) {
         return new CloseAction(defaultExecutor, myDescriptor, project);
     }
 
-    protected AnAction createStopAction() {
-        return ActionManager.getInstance().getAction(IdeActions.ACTION_STOP_PROGRAM);
+    protected AnAction createRestartAction(final Executor defaultExecutor, final RunContentDescriptor myDescriptor) {
+        return new AnAction("Restart", "Restarts the REPL", AllIcons.Actions.Restart) {
+
+            @Override
+            public void actionPerformed(AnActionEvent anActionEvent) {
+                createCloseAction(defaultExecutor, myDescriptor).actionPerformed(anActionEvent);
+                new RunJavaREPLConsoleAction().actionPerformed(anActionEvent);
+            }
+        };
     }
 
     private GeneralCommandLine createCommandLine(Module module, String workingDir) throws CantRunException {


### PR DESCRIPTION
This adds a button that performs the equivalent of closing the REPL and starting it again. This is useful for times when you need to quickly restart it, such as when you want to redefine a class. Updating the deps also seems to fix a crash I intermittently experienced.