### PR TITLE
Ignore brackets in strings

### DIFF
--- a/src/javarepl/ExpressionReader.java
+++ b/src/javarepl/ExpressionReader.java
@@ -15,6 +15,7 @@ public class ExpressionReader {
     final static Sequence<Character> openBrackets = sequence('[', '{', '(');
     final static Sequence<Character> closedBrackets = sequence(']', '}', ')');
     final static Map<Character, Character> matchingBrackets = Maps.map(closedBrackets.zip(openBrackets));
+    final static Sequence<Character> quotes = sequence('\'', '"');
 
     private final Mapper<Sequence<String>, String> lineReader;
 
@@ -43,8 +44,25 @@ public class ExpressionReader {
         if (hasTwoEmptyLines(strings))
             return true;
 
+        boolean isEscaped = false; // whether the current character is preceded by a backslash
+        Character quote = null; // the quote character currently used, or null if not quoted
+
         LinkedList<Character> brackets = new LinkedList<Character>();
         for (Character character : characters) {
+            if (isQuote(character) && !isEscaped) {
+                if (quote == null) { // opening quote
+                    quote = character;
+                } else if (quote.equals(character)) { // closing quote
+                    quote = null;
+                }
+            }
+
+            isEscaped = !isEscaped && character != null && character.equals('\\');
+
+            if (quote != null) { // if we're in quoted text, ignore the brackets
+                continue;
+            }
+
             if (isOpeningBracket(character)) {
                 brackets.push(character);
             }
@@ -75,6 +93,10 @@ public class ExpressionReader {
 
     private static boolean isOpeningBracket(Character character) {
         return openBrackets.contains(character);
+    }
+
+    private static boolean isQuote(Character character) {
+        return quotes.contains(character);
     }
 
     private static boolean hasNullLine(Sequence<String> strings) {


### PR DESCRIPTION
This fixes #61 by ignoring the brackets if they are inside a quoted literal.