### PR TITLE
Fixing String evaluation

### DIFF
--- a/src/javarepl/expressions/Patterns.java
+++ b/src/javarepl/expressions/Patterns.java
@@ -46,7 +46,7 @@ public class Patterns {
     }
 
     public static boolean isValidAssignment(String string) {
-        return assignmentPattern.matches(string.trim());
+        return !string.contains("==") && assignmentPattern.matches(string.trim());
     }
 
     public static boolean isValidAssignmentWithType(String string) {

--- a/test/javarepl/EvaluatorTest.java
+++ b/test/javarepl/EvaluatorTest.java
@@ -41,6 +41,7 @@ public class EvaluatorTest {
         assertThat(evaluating("class NewClass {public int field=20;}", "new NewClass().field"), hasResult(20));
         assertThat(evaluating("int max(int a, int b) { return a > b ? a : b; }", "max(20, 30)"), hasResult(30));
         assertThat(evaluating("String res = null", "res"), hasResult(null));
+        assertThat(evaluating("String a = \"My String\";", "String b = \"My String\";", "a == b"), hasResult(true));
     }
 
     @Test

--- a/test/javarepl/expressions/PatternsTest.java
+++ b/test/javarepl/expressions/PatternsTest.java
@@ -31,7 +31,9 @@ public class PatternsTest {
         assertTrue(isValidAssignment("val =42"));
         assertTrue(isValidAssignment("val= 42"));
         assertTrue(isValidAssignment("  val  =   42  42  "));
+
         assertFalse(isValidAssignment("val wrong=   42  42  "));
+        assertFalse(isValidAssignment("a == b"));
 
         MatchResult result = assignmentPattern.match("val = 42");
         assertThat(result.group(1), is("val"));


### PR DESCRIPTION
Hi,

Recently I made a very simple test with the REPL and found a weird error. The test went something like this:
 ```
Welcome to JavaREPL version dev.build (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_51)
Type expression to evaluate, :help for more options or press tab to auto-complete.
java> String a = "My String"
java.lang.String a = "My String"
java> String b = "My String"
java.lang.String b = "My String"
java> a == b
ERROR: illegal start of expression
    = b;
    ^
java> :quit

Terminating...
```
By taking a look at the code I could spot the cause, it turns out that the evaluation was being parsed as an `Assignment` but in this case it should be a `Value`.

I believe this PR is the most simple solution I could find. Feedback on code is always welcome.

P.S: This project is just awesome! 