### PR TITLE
Update jline to 2.14.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -196,7 +196,7 @@ dependencies {
     compile "com.googlecode.totallylazy:totallylazy:2.249"
     compile "com.googlecode.utterlyidle:utterlyidle:2.108"
     compile "com.googlecode.yadic:yadic:2.48"
-    compile "jline:jline:2.14.2"
+    compile "jline:jline:2.14.5"
 
     testCompile "org.hamcrest:hamcrest-core:1.3"
     testCompile "org.hamcrest:hamcrest-library:1.3"


### PR DESCRIPTION
This solves the following errors in Arch Linux:
```
[ERROR] Failed to construct terminal; falling back to unsupported
java.lang.NumberFormatException: For input string: "0x100"
	at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
	at java.lang.Integer.parseInt(Integer.java:580)
	at java.lang.Integer.valueOf(Integer.java:766)
	at javarepl.internal.jline.internal.InfoCmp.parseInfoCmp(InfoCmp.java:59)
	at javarepl.internal.jline.UnixTerminal.parseInfoCmp(UnixTerminal.java:242)
	at javarepl.internal.jline.UnixTerminal.<init>(UnixTerminal.java:65)
	at javarepl.internal.jline.UnixTerminal.<init>(UnixTerminal.java:50)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at java.lang.Class.newInstance(Class.java:442)
	at javarepl.internal.jline.TerminalFactory.getFlavor(TerminalFactory.java:211)
	at javarepl.internal.jline.TerminalFactory.create(TerminalFactory.java:102)
	at javarepl.internal.jline.TerminalFactory.get(TerminalFactory.java:186)
	at javarepl.internal.jline.TerminalFactory.get(TerminalFactory.java:192)
	at javarepl.internal.jline.console.ConsoleReader.<init>(ConsoleReader.java:243)
	at javarepl.internal.jline.console.ConsoleReader.<init>(ConsoleReader.java:235)
	at javarepl.internal.jline.console.ConsoleReader.<init>(ConsoleReader.java:227)
	at javarepl.Main.main(Main.java:55)

```